### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/adamgreig/sheepdog.png?branch=master)](https://travis-ci.org/adamgreig/sheepdog)
 [![Coverage Status](https://coveralls.io/repos/adamgreig/sheepdog/badge.png?branch=master)](https://coveralls.io/r/adamgreig/sheepdog?branch=master)
-[![PyPi Version](https://pypip.in/v/Sheepdog/badge.png)](https://pypi.python.org/pypi/Sheepdog/)
-[![License](https://pypip.in/license/Sheepdog/badge.png)](https://pypi.python.org/pypi/Sheepdog/)
+[![PyPi Version](https://img.shields.io/pypi/v/Sheepdog.svg)](https://pypi.python.org/pypi/Sheepdog/)
+[![License](https://img.shields.io/pypi/l/Sheepdog.svg)](https://pypi.python.org/pypi/Sheepdog/)
 
 Make Grid Engine a bit more useful from Python.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sheepdog))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sheepdog`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.